### PR TITLE
Fix/wrong default error code

### DIFF
--- a/check-consul
+++ b/check-consul
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=v0.1.0
+VERSION=v0.1.1
 
 HOST=127.0.0.1
 PORT=8500

--- a/check-consul
+++ b/check-consul
@@ -24,7 +24,7 @@ function getoptions() {
 }
 
 function leader_lost() {
-    ALERT_STATUS=1
+    ALERT_STATUS=2
     getoptions "$@"
     
     curl -s http://$HOST:$PORT/v1/status/leader | egrep -q '^".+"$'


### PR DESCRIPTION
default alert level of `check-consul leader-lost` should be 2