### PR TITLE
add leader changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ check-consul [subcommand] [options]...
         -w  set alert level WARNING. exit status 1. (default: not selected)
         -c  set alert level CRITICAL. exit status 2. (default: selected)
 
+### check-consul leader-changed [-h host] [-p port] [-w] [-c]
+    Description:
+        alert when consul leader changed.
+
+    Options:
+        -h  consul agent host (default: 127.0.0.1)
+        -p  consul agent port (default: 8500)
+        -w  set alert level WARNING (exit status 1). (default: selected)
+        -c  set alert level CRITICAL (exit status 2). (default: not selected)
+
 ### check-consul server-nodes-changed [-h host] [-p port] [-t temp_file] [-w] [-c]
     Description:
         alert when consul server nodes list changed.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ check-consul [subcommand] [options]...
         -w  set alert level WARNING. exit status 1. (default: not selected)
         -c  set alert level CRITICAL. exit status 2. (default: selected)
 
-### check-consul leader-changed [-h host] [-p port] [-w] [-c]
+### check-consul leader-changed [-h host] [-p port] [-t temp_file] [-w] [-c]
     Description:
         alert when consul leader changed.
 
     Options:
         -h  consul agent host (default: 127.0.0.1)
         -p  consul agent port (default: 8500)
+        -t  save previous leader. (default: /var/tmp/mackerel-agent/consul-leader-changed)
         -w  set alert level WARNING (exit status 1). (default: selected)
         -c  set alert level CRITICAL (exit status 2). (default: not selected)
 

--- a/check-consul
+++ b/check-consul
@@ -110,6 +110,7 @@ check-consul leader-changed [-h host] [-p port] [-w] [-c]
     Options:
         -h  consul agent host (default: 127.0.0.1)
         -p  consul agent port (default: 8500)
+        -t  save previous leader. (default: /var/tmp/mackerel-agent/consul-leader-changed)
         -w  set alert level WARNING (exit status 1). (default: selected)
         -c  set alert level CRITICAL (exit status 2). (default: not selected)
 

--- a/check-consul
+++ b/check-consul
@@ -103,7 +103,7 @@ check-consul leader-lost [-h host] [-p port] [-w] [-c]
         -w  set alert level WARNING (exit status 1). (default: not selected)
         -c  set alert level CRITICAL (exit status 2). (default: selected)
 
-check-consul leader-changed [-h host] [-p port] [-w] [-c]
+check-consul leader-changed [-h host] [-p port] [-t temp_file] [-w] [-c]
     Description:
         alert when consul leader changed.
 

--- a/check-consul
+++ b/check-consul
@@ -41,17 +41,17 @@ function leader_changed() {
     ALERT_STATUS=1
     getoptions "$@"
 
-    PEERS="$(curl -s http://$HOST:$PORT/v1/status/leader)"
+    LEADER="$(curl -s http://$HOST:$PORT/v1/status/leader)"
 
     if [[ ! -f $TEMP_FILE ]]; then
-        echo "$PEERS" > $TEMP_FILE
+        echo "$LEADER" > $TEMP_FILE
     fi
 
-    diff $TEMP_FILE <(echo "$PEERS")
+    diff $TEMP_FILE <(echo "$LEADER")
 
     STATUS=$?
 
-    echo "$PEERS" > $TEMP_FILE
+    echo "$LEADER" > $TEMP_FILE
 
     if [[ $STATUS != "0" ]]; then
         exit $ALERT_STATUS

--- a/check-consul
+++ b/check-consul
@@ -36,6 +36,30 @@ function leader_lost() {
     exit 0
 }
 
+function leader_changed() {
+    TEMP_FILE=/var/tmp/mackerel-agent/consul-leader-changed
+    ALERT_STATUS=1
+    getoptions "$@"
+
+    PEERS="$(curl -s http://$HOST:$PORT/v1/status/leader)"
+
+    if [[ ! -f $TEMP_FILE ]]; then
+        echo "$PEERS" > $TEMP_FILE
+    fi
+
+    diff $TEMP_FILE <(echo "$PEERS")
+
+    STATUS=$?
+
+    echo "$PEERS" > $TEMP_FILE
+
+    if [[ $STATUS != "0" ]]; then
+        exit $ALERT_STATUS
+    fi
+
+    exit 0
+}
+
 function server_nodes_changed() {
     TEMP_FILE=/var/tmp/mackerel-agent/consul-server-nodes-changed
     ALERT_STATUS=1
@@ -99,6 +123,8 @@ EOC
 case ${1} in
     leader-lost)
         leader_lost "$@";;
+    leader-changed)
+        leader_changed "$@";;
     server-nodes-changed)
         server_nodes_changed "$@";;
     version)

--- a/check-consul
+++ b/check-consul
@@ -103,6 +103,16 @@ check-consul leader-lost [-h host] [-p port] [-w] [-c]
         -w  set alert level WARNING (exit status 1). (default: not selected)
         -c  set alert level CRITICAL (exit status 2). (default: selected)
 
+check-consul leader-changed [-h host] [-p port] [-w] [-c]
+    Description:
+        alert when consul leader changed.
+
+    Options:
+        -h  consul agent host (default: 127.0.0.1)
+        -p  consul agent port (default: 8500)
+        -w  set alert level WARNING (exit status 1). (default: selected)
+        -c  set alert level CRITICAL (exit status 2). (default: not selected)
+
 check-consul server-nodes-changed [-h host] [-p port] [-t temp_file] [-w] [-c]
     Description:
         alert when consul server nodes list changed.


### PR DESCRIPTION
add `check-consul leader-changed`

```
check-consul leader-changed [-h host] [-p port] [-t temp_file] [-w] [-c]
    Description:
        alert when consul leader changed.

    Options:
        -h  consul agent host (default: 127.0.0.1)
        -p  consul agent port (default: 8500)
        -t  save previous leader. (default: /var/tmp/mackerel-agent/consul-leader-changed)
        -w  set alert level WARNING (exit status 1). (default: selected)
        -c  set alert level CRITICAL (exit status 2). (default: not selected)
```